### PR TITLE
Fix UnicodeEncodeError when using Python 2.7

### DIFF
--- a/pybib/main.py
+++ b/pybib/main.py
@@ -1,7 +1,11 @@
+import sys
+# Workaround to make pybib run with Python 2.7 if default encoding is ascii
+if sys.version_info[0] < 3:
+    reload(sys)
+    sys.setdefaultencoding('utf8')
 import argparse
 import pybib
 import termstyle
-import sys
 
 def search_cmd(args):
     query = " ".join(args.query)


### PR DESCRIPTION
Hi jgilchrist,

This workaround fixes an encoding issue I ran into when trying to use pybib with Python 2.7.
If text contains non-ascii characters Python 2.7 throws a UnicodeEncodeError and pybib won't work. 
It might not be the most elegant way to fix this issue, but it does the job :)

All the best,
-Andreas